### PR TITLE
Add archiver

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,6 +3,7 @@
 # Find out more: https://morph.io/documentation/ruby
 
 source "https://rubygems.org"
+git_source(:github) { |repo_name| "https://github.com/#{repo_name}.git" }
 
 ruby "2.0.0"
 
@@ -14,3 +15,4 @@ gem "nokogiri"
 gem "open-uri-cached"
 gem "fuzzy_match"
 gem 'wikidata-client', '~> 0.0.7', require: 'wikidata'
+gem 'scraped_page_archive', github: 'everypolitician/scraped_page_archive'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,4 +1,12 @@
 GIT
+  remote: https://github.com/everypolitician/scraped_page_archive.git
+  revision: 317f10cf3c6abbfb7f1871e80c73b8d8cf07f07a
+  specs:
+    scraped_page_archive (0.4.1)
+      git (~> 1.3.0)
+      vcr-archive (~> 0.3.0)
+
+GIT
   remote: https://github.com/openaustralia/scraperwiki-ruby.git
   revision: fc50176812505e463077d5c673d504a6a234aa78
   branch: morph_defaults
@@ -10,8 +18,11 @@ GIT
 GEM
   remote: https://rubygems.org/
   specs:
+    addressable (2.4.0)
     coderay (1.1.0)
     colorize (0.7.7)
+    crack (0.4.3)
+      safe_yaml (~> 1.0.0)
     excon (0.45.4)
     execjs (2.5.2)
     faraday (0.9.1)
@@ -19,6 +30,8 @@ GEM
     faraday_middleware (0.10.0)
       faraday (>= 0.7.4, < 0.10)
     fuzzy_match (2.1.0)
+    git (1.3.0)
+    hashdiff (0.3.0)
     hashie (3.4.2)
     httpclient (2.6.0.1)
     method_source (0.8.2)
@@ -31,10 +44,19 @@ GEM
       coderay (~> 1.1.0)
       method_source (~> 0.8.1)
       slop (~> 3.4)
+    safe_yaml (1.0.4)
     slop (3.6.0)
     sqlite3 (1.3.10)
     sqlite_magic (0.0.3)
       sqlite3
+    vcr (3.0.3)
+    vcr-archive (0.3.0)
+      vcr (~> 3.0.2)
+      webmock (~> 2.0.3)
+    webmock (2.0.3)
+      addressable (>= 2.3.6)
+      crack (>= 0.3.2)
+      hashdiff
     wikidata-client (0.0.7)
       excon (~> 0.40)
       faraday (~> 0.9)
@@ -51,5 +73,6 @@ DEPENDENCIES
   nokogiri
   open-uri-cached
   pry
+  scraped_page_archive!
   scraperwiki!
   wikidata-client (~> 0.0.7)

--- a/scraper.rb
+++ b/scraper.rb
@@ -5,8 +5,9 @@ require 'scraperwiki'
 require 'nokogiri'
 require 'colorize'
 require 'pry'
-require 'open-uri/cached'
-OpenURI::Cache.cache_path = '.cache'
+# require 'open-uri/cached'
+# OpenURI::Cache.cache_path = '.cache'
+require 'scraped_page_archive/open-uri'
 
 class String
   def tidy

--- a/scraper.rb
+++ b/scraper.rb
@@ -24,8 +24,10 @@ def scrape_list(url)
   puts url.to_s.magenta
 
   noko.css('#ctl00_ContentPlaceHolder1_GridView1 table a').to_a.uniq { |n| n.attr('href') }.each do |a|
-    # too many variations in layout on these pages to usefully scrape...
+    # too many variations in layout on these pages to usefully scrape... loading them just to archive
     link = URI.join(url, a.attr('href')).to_s
+    member_page = open(link)
+
     data = {
       id: link[/Id=(\d+)/, 1],
       name: a.text.tidy,

--- a/scraper.rb
+++ b/scraper.rb
@@ -26,7 +26,7 @@ def scrape_list(url)
   noko.css('#ctl00_ContentPlaceHolder1_GridView1 table a').to_a.uniq { |n| n.attr('href') }.each do |a|
     # too many variations in layout on these pages to usefully scrape...
     link = URI.join(url, a.attr('href')).to_s
-    data = { 
+    data = {
       id: link[/Id=(\d+)/, 1],
       name: a.text.tidy,
       image: a.xpath('following::img[contains(@src,"Images")][1]/@src').text,


### PR DESCRIPTION
## Scraper page
- [x] scraper is on Morph.io under the "everypolitician-scrapers" group
- [x] scraper's GitHub repo links to scraper on `morph.io/everypolitician-scrapers/...` ("website" at top of page)
- [ ] _maybe_ the database on morph should be cleared? --> See [*]
- [x] scraper is set to auto-run
## Scraped page archive
- [x] scraper uses scraped archive gem (unless upstream source has its own archive)
- [x] repo URL uses `https` not `git@` (until [#37 is solved](https://github.com/everypolitician/scraped_page_archive/issues/37)) 
- [x] all gemfile links are secure (e.g., use https)
- [x] morph is configured to write to GitHub ("secret" environment vars)
- [x] pages are archived in new branch of correct scraper repo (yay!)

The member pages **are being visited but not scraped**, as shown in the archiver branch (urls with `Id` are member pages, urls with `Page` are pagination):

![member-pages](https://cloud.githubusercontent.com/assets/2157089/19688463/c4234804-9ac1-11e6-8234-8d3a924f9121.png)

[*] The data was rebuilt with the information produced by the scraper and new people seem to be added so apparently the people from the new term may be starting to be added to the official site (Parliamentary elections were scheduled to be held in Afghanistan on 15 October 2016). The [old morph scraper page](https://morph.io/tmtmtmtm/afghanistan-assembly) shows  228 total members (run a year ago) while [the new](https://morph.io/everypolitician-scrapers/afghanistan-assembly) shows 258.
